### PR TITLE
chore: set_app_id_via_selected_app_name 테스트 추가

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from functions.functions import set_app_id_via_selected_app_name
+
+
+@pytest.mark.parametrize(
+    "expected_app_id, selected_app_name, app_list",
+    [
+        ("a1", "some_first_app", [{"app_name": "some_first_app", "app_id": "a1"}, {"app_name": "some_second_app", "app_id": "a2"}]),
+        ("a2", "some_second_app", [{"app_name": "some_first_app", "app_id": "a1"}, {"app_name": "some_second_app", "app_id": "a2"}])
+    ]
+)
+def test_set_app_id_via_selected_app_name(expected_app_id, selected_app_name, app_list):
+    with patch('streamlit.session_state', new_callable=dict) as mock_st:
+        mock_st["selected_app_name"] = selected_app_name
+        mock_st["app_list"] = app_list
+
+        sut = set_app_id_via_selected_app_name
+
+        assert sut() == expected_app_id
+
+


### PR DESCRIPTION
### 변경의 내용 (Motivation)

- set_app_id_via_selected_app_name 의 테스트 코드를 추가하였습니다

### (Optional) 기대 효과(Intended Effects)

- set_app_id_via_selected_app_name 의 테스트가 정상 동작합니다

### (Optional) 테스트 방법(How Has This Been Tested?)

- 테스트 방법1 (Test approach 1)
   ```shell
   pytest -v tests/
   ```
